### PR TITLE
feat: fix for deprecated variable defined

### DIFF
--- a/cashfree.php
+++ b/cashfree.php
@@ -11,9 +11,9 @@
  * Text Domain: woocommerce-extension
  * Domain Path: /languages
  * Requires at least: 4.4
- * Tested up to: 6.5
+ * Tested up to: 6.6
  * WC requires at least: 3.0
- * WC tested up to: 8.8
+ * WC tested up to: 9.2
  *
  *
  * License: GPLv3

--- a/cashfree.php
+++ b/cashfree.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Cashfree
- * Version: 4.7.2
+ * Version: 4.7.3
  * Plugin URI: https://github.com/cashfree/cashfree-woocommerce
  * Description: Payment gateway plugin by Cashfree Payments for Woocommerce sites.
  * Author: devcashfree
@@ -50,6 +50,8 @@ class WC_Cashfree {
 	 * @var array
 	 */
 	private $settings;
+
+	private $enabled;
 
 	/**
 	 * A log object returned by wc_get_logger().

--- a/includes/class-wc-cashfree-api.php
+++ b/includes/class-wc-cashfree-api.php
@@ -15,6 +15,8 @@ class WC_Cashfree_Api {
 	 *
 	 * @param string $id Api identifier.
 	 */
+	private $id;
+	
 	public function __construct( $id ) {
 		$this->id = $id;
 

--- a/includes/gateways/class-wc-cashfree-block-support.php
+++ b/includes/gateways/class-wc-cashfree-block-support.php
@@ -7,6 +7,8 @@ defined( 'ABSPATH' ) || exit;
 final class WC_Cashfree_Blocks_Support extends AbstractPaymentMethodType {
 
 	protected $name = 'cashfree';
+	protected $settings = [];
+    protected $gateway;
 
 	/**
 	 * Initializes the payment method type.

--- a/includes/gateways/class-wc-cashfree-gateway.php
+++ b/includes/gateways/class-wc-cashfree-gateway.php
@@ -12,13 +12,47 @@ require_once ABSPATH . 'wp-admin/includes/plugin.php';
  */
 abstract class WC_Cashfree_Gateway extends WC_Payment_Gateway {
 
-	/**
-	 * Cashfree adapter instance.
-	 *
-	 * @var WC_Cashfree_Adapter
-	 */
+	 /**
+     * Cashfree adapter instance.
+     *
+     * @var WC_Cashfree_Adapter
+     */
+    protected $adapter;
 
-	protected $adapter;
+    /**
+     * Sandbox mode enabled.
+     *
+     * @var bool
+     */
+    protected $sandbox;
+
+    /**
+     * Debug mode enabled.
+     *
+     * @var bool
+     */
+    protected $debug;
+
+    /**
+     * Token parameter name.
+     *
+     * @var string
+     */
+    protected $token_param;
+
+    /**
+     * Order ID prefix enabled.
+     *
+     * @var bool
+     */
+    protected $order_id_prefix_text;
+
+    /**
+     * Order in context enabled.
+     *
+     * @var bool
+     */
+    protected $order_in_context;
 
 	/**
 	 * Constructor.

--- a/readme.txt
+++ b/readme.txt
@@ -50,6 +50,9 @@ The manual installation method involves downloading our plugin and uploading it 
 
 == Changelog ==
 
+= 4.7.3 =
+* Deprecated Property Fix: Updated the cashfree classes to prevent deprecated warnings in PHP 8.2 and later by explicitly declaring properties instead of using dynamic properties.
+
 = 4.7.2 =
 * Added additional data to get trace of the request
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: devcashfree
 Requires at least: 4.4
 Tested up to: 6.5
 Requires PHP: 5.6
-Stable tag: 4.7.2
-Version: 4.7.2
+Stable tag: 4.7.3
+Version: 4.7.3
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Tags: wordpress,woocommerce,payment,gateway,cashfree


### PR DESCRIPTION
Deprecated Property Fix: Updated the cashfree classes to prevent deprecated warnings in PHP 8.2 and later by explicitly declaring properties instead of using dynamic properties.